### PR TITLE
fix(ci): run the desktop build step under bash on Windows runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,8 @@ jobs:
 
       - name: Build Desktop App
         working-directory: ./desktop
+        # Windows runners default to PowerShell, which cannot read this syntax.
+        shell: bash
         run: |
           # Stamp the same build info the CLI gets from GoReleaser.
           VERSION=${GITHUB_REF#refs/tags/v}
@@ -126,6 +128,8 @@ jobs:
 
       - name: Build Desktop App
         working-directory: ./desktop
+        # Windows runners default to PowerShell, which cannot read this syntax.
+        shell: bash
         run: |
           # Stamp the same build info the CLI gets from GoReleaser.
           VERSION=${GITHUB_REF#refs/tags/v}
@@ -184,6 +188,8 @@ jobs:
 
       - name: Build Desktop App
         working-directory: ./desktop
+        # Windows runners default to PowerShell, which cannot read this syntax.
+        shell: bash
         run: |
           # Stamp the same build info the CLI gets from GoReleaser.
           VERSION=${GITHUB_REF#refs/tags/v}
@@ -235,6 +241,8 @@ jobs:
 
       - name: Build Desktop App
         working-directory: ./desktop
+        # Windows runners default to PowerShell, which cannot read this syntax.
+        shell: bash
         run: |
           # Stamp the same build info the CLI gets from GoReleaser.
           VERSION=${GITHUB_REF#refs/tags/v}
@@ -291,6 +299,8 @@ jobs:
 
       - name: Build Desktop App
         working-directory: ./desktop
+        # Windows runners default to PowerShell, which cannot read this syntax.
+        shell: bash
         run: |
           # Stamp the same build info the CLI gets from GoReleaser.
           VERSION=${GITHUB_REF#refs/tags/v}


### PR DESCRIPTION
The v0.4.1 release build failed on both Windows desktop jobs:

```
VERSION=${GITHUB_REF#refs/tags/v}: The term 'VERSION=${GITHUB_REF#refs/tags/v}'
is not recognized as a name of a cmdlet, function, script file, or operable program.
```

Windows runners default to PowerShell, and the build-info stamping added in #21 is written in bash. Pinning `shell: bash` on that step keeps one syntax across all five desktop jobs; bash ships with the Windows runner image.

The macOS and Linux desktop jobs and the CLI build all succeeded, so this only affects the two Windows targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)